### PR TITLE
docs: update installation guide to use pipx instead of venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,11 @@ git clone https://github.com/yourusername/git-sage.git
 # Navigate to project directory
 cd git-sage
 
-# Create and activate virtual environment (recommended)
-python3 -m venv venv
-source venv/bin/activate  # On Windows, use: venv\Scripts\activate
+# Install pipx if you haven't already
+brew install pipx
 
-# Install in development mode
-pip install -e .
+# Install Git Sage using pipx
+pipx install -e .
 
 # Configure Git Sage
 gsg set

--- a/README_CN.md
+++ b/README_CN.md
@@ -21,14 +21,13 @@ git clone https://github.com/yourusername/git-sage.git
 # 进入项目目录
 cd git-sage
 
-# 创建并激活虚拟环境（推荐）
-python3 -m venv venv
-source venv/bin/activate  # Windows系统使用: venv\Scripts\activate
+# 安装 pipx（如果尚未安装）
+brew install pipx
 
-# 以开发模式安装
-pip install -e .
+# 使用 pipx 安装 Git Sage
+pipx install -e .
 
-# 配置Git Sage
+# 配置 Git Sage
 gsg set
 ```
 


### PR DESCRIPTION
Replace virtual environment setup with pipx installation in both README.md and README_CN.md for better user experience and global command availability