### PR TITLE
feat: Improve commit message style by avoiding self-referential phrases

### DIFF
--- a/git_sage/core/ai_processor.py
+++ b/git_sage/core/ai_processor.py
@@ -186,6 +186,17 @@ You are a professional code reviewer and commit message generator. Please carefu
 - Confirm if the chosen change type tag is most accurate
 - Verify if the description completely and accurately reflects the essence of changes
 
+IMPORTANT WRITING STYLE:
+Write commit messages in an active, direct style. Avoid self-referential phrases like "this commit", "this change", "this update", "this modification". Instead, describe what the change does directly using imperative mood.
+
+Examples:
+- Bad: "This commit adds user authentication"
+- Good: "Add user authentication"
+- Bad: "This change fixes a bug in user login" 
+- Good: "Fix user login validation issue"
+- Bad: "This update improves performance"
+- Good: "Improve database query performance"
+
 Commit Tags Explanation:
 
 Patch Version (PATCH) Tags:


### PR DESCRIPTION
Add writing style guidance to AI processor to eliminate phrases like "this commit", "this change", "this update" in generated commit messages. The prompt now instructs the AI to use imperative mood and direct descriptions for more professional and concise commit messages following Git best practices.