### PR TITLE
Feat:[] 为 'pr' 命令添加 --no-verify 选项

### DIFF
--- a/git_sage/cli/main.py
+++ b/git_sage/cli/main.py
@@ -314,7 +314,8 @@ def init_prompts():
 
 @cli.command()
 @click.option('--dry-run', '-n', is_flag=True, help='仅显示PR信息，不创建')
-def pr(dry_run):
+@click.option('--no-verify', '-nv', is_flag=True, help='设置QA部分为None')
+def pr(dry_run, no_verify):
     """生成并创建 Pull Request"""
     try:
         # Initialize modules
@@ -350,7 +351,7 @@ def pr(dry_run):
         
         # Generate PR content using AI
         click.echo("正在生成 PR 内容...")
-        pr_content = ai_processor.generate_pr_content(commits, diff_content, ticket)
+        pr_content = ai_processor.generate_pr_content(commits, diff_content, ticket, no_verify)
         
         # Display PR information
         click.echo("\n" + "="*50)


### PR DESCRIPTION
### Description
此 PR 为 `pr` 命令引入了一个新的 `--no-verify` 选项，允许用户在生成 Pull Request 描述时，强制将 QA 部分设置为 `[QA: None]`。
- 在 `git sage pr` 命令中新增了 `--no-verify` (或 `-nv`) 命令行选项。
- 优化了 AI 生成 PR 内容的逻辑，使其能够根据 `--no-verify` 标志动态调整 PR 描述中的 QA 部分指令。
- 确保在 PR 描述生成失败的默认回退逻辑中，QA 部分也能正确响应 `--no-verify` 选项。
- 提升了 `pr` 命令的灵活性，适用于无需人工 QA 验证的改动，例如纯后端逻辑、重构或文档更新。

### Related issues or context
- No related ticket

### QA
[QA: Verify]
- 运行 `git sage pr --no-verify` 命令，验证生成的 PR 描述中的 QA 部分是否为 `[QA: None]`。
- 运行 `git sage pr` 命令（不带 `--no-verify` 选项），验证生成的 PR 描述中的 QA 部分是否包含详细的验证指令。